### PR TITLE
Fix matplotlib dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     numpy>=1.16.3
     astropy>=3.1.2
     astroscrappy>=1.0.8
+    matplotlib>=3.1.1
     tqdm
     scikit-image>=0.15.0;python_version>='3.7'
     scikit-image==0.15.*;python_version<'3.7'


### PR DESCRIPTION
This doesn't get pulled in when running "pip install deepCR" from PyPI, which leads to "ModuleNotFoundError: No module named 'matplotlib'"

https://github.com/profjsb/deepCR/blob/0245290123f0f4b745a6571841fe488bb267edd4/deepCR/training.py#L5